### PR TITLE
ui improvements, and some fixes of the ida plugin

### DIFF
--- a/examples/ida_binaryai.py
+++ b/examples/ida_binaryai.py
@@ -68,7 +68,7 @@ class BinaryAIManager:
     def get_binaryai_function_color(self):
         return self.cfg['funccolor'] if 'funccolor' in self.cfg else BinaryAIManager.Default['funccolor']
 
-    def binaryai_calllback(self, __):
+    def binaryai_callback(self, __):
         print("[{}] v{}".format(self.name, bai.__version__))
 
     def retrieve_function_callback(self, __, ea=None):
@@ -191,7 +191,7 @@ class UIManager:
         action2 = UIManager.ActionHandler("BinaryAI:RetrieveFunction", "Retrieve function", "Ctrl+Shift+d", icon=199)
         action3 = UIManager.ActionHandler("BinaryAI:RetrieveAll", "Retrieve all functions", "", icon=188)
         action4 = UIManager.ActionHandler("BinaryAI:RetrieveSelected", "Retrieve")
-        if action1.register_action(self.mgr.binaryai_calllback, toolbar_name) and \
+        if action1.register_action(self.mgr.binaryai_callback, toolbar_name) and \
             action2.register_action(self.mgr.retrieve_function_callback, toolbar_name, menupath) and \
                 action3.register_action(self.mgr.retrieve_all_callback, toolbar_name, menupath) and \
                 action4.register_action(self.retrieve_selected_callback):


### PR DESCRIPTION
I modified the ida plugin to don't use/abuse the lumina flag,

it now uses our own color scheme (customizable) and netnodes for persistence, and it will mark in light blue (by default) the binaryai functions

![image](https://user-images.githubusercontent.com/1010159/83102971-552b9d80-a0e8-11ea-946b-f4c018657476.png)

there is a new dependency for the ida plugin only, which is `ida_netnode`, but it's not required for the sdk, so it can be installed if someone want to use the ida plugin